### PR TITLE
Adding PI identifier to DATS.json

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -57,7 +57,7 @@
       "lastName": "Khan",
       "roles": [
 		{
-			"Principal Investigator"
+			"value": "Principal Investigator"
 		}
       ],
       "affiliations":

--- a/DATS.json
+++ b/DATS.json
@@ -55,6 +55,11 @@
       "firstName": "Ali",
       "middleInitial": "R.",
       "lastName": "Khan",
+      "roles": [
+		{
+			"Principal Investigator"
+		}
+      ],
       "affiliations":
       [
         {


### PR DESCRIPTION
This PR adds the value of "Principal Investigator" in `roles->name` for Ali Khan under `creators` in the DATS.json file.